### PR TITLE
Feat/store photo

### DIFF
--- a/QRHunter/app/build.gradle
+++ b/QRHunter/app/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
     implementation 'com.google.firebase:firebase-crashlytics-buildtools:2.8.1'
     implementation 'com.google.android.gms:play-services-location:21.0.1'
+    implementation 'com.google.firebase:firebase-storage:20.1.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/PlayerRepository.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/PlayerRepository.java
@@ -11,6 +11,8 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -134,5 +136,14 @@ public class PlayerRepository extends DataRepository {
         });
         return usersLiveData;
     }
+
+    public void uploadPhoto(byte[] savedPhoto, String qrCodeId, String playerId) {
+        StorageReference storageReference = FirebaseStorage.getInstance().getReference();
+        if (savedPhoto != null){
+            storageReference.child("photos").child(qrCodeId).child(playerId).putBytes(savedPhoto);
+        }
+
+    }
+
 
 }

--- a/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/QRCodeRepository.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/QRCodeRepository.java
@@ -41,7 +41,6 @@ public class QRCodeRepository extends DataRepository {
                 String photoPath;
                 ArrayList<String> photos = new ArrayList<>();
                 String qrCodeId = qrCode.getId();
-                Log.d("================================", "savedPhoto: "+savedPhoto);
                 if (savedPhoto == null) {
                     photoPath = null;
                 }

--- a/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/QRCodeRepository.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/QRCodeRepository.java
@@ -45,7 +45,7 @@ public class QRCodeRepository extends DataRepository {
                     photoPath = null;
                 }
                 else {
-                    photoPath = "photos/" + qrCodeId + "/" + playerId + ".png";
+                    photoPath = "photos/" + qrCodeId + "/" + playerId + ".jpg";
                     photos.add(photoPath);
                     qrCode.setPhotos(photos);
                 }
@@ -65,7 +65,7 @@ public class QRCodeRepository extends DataRepository {
                     photoPath = null;
                 }
                 else {
-                    photoPath = "photos/" + existingQRCode.getId() + "/" + playerId + ".png";
+                    photoPath = "photos/" + existingQRCode.getId() + "/" + playerId + ".jpg";
                     existingPhotos.add(photoPath);
                     qrCode.setPhotos(existingPhotos);
                 }
@@ -103,7 +103,7 @@ public class QRCodeRepository extends DataRepository {
     public void removeQRCodeFromPlayer(String qrCodeId, String playerId) {
         PlayerRepository playerRepository = new PlayerRepository();
 
-        String photoPath = "photos/" + qrCodeId + "/" + playerId + ".png";
+        String photoPath = "photos/" + qrCodeId + "/" + playerId + ".jpg";
 
         // Update qr code document, remove player id. photo path and location.
         db.collection("qrCodes").document(qrCodeId)

--- a/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/AfterScanFragment.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/AfterScanFragment.java
@@ -112,7 +112,7 @@ public class AfterScanFragment extends Fragment {
                             Intent data = result.getData();
                             Bundle bundle = data.getExtras();
                             savedPhoto = (Bitmap) bundle.get("data");
-                            savedPhoto = Bitmap.createScaledBitmap(savedPhoto, 640, 480, true);
+                            savedPhoto = Bitmap.createScaledBitmap(savedPhoto, 480, 640, true);
                             scanViewModel.setPhoto(savedPhoto);
 
                             binding.locationImage.setVisibility(View.VISIBLE);
@@ -153,6 +153,7 @@ public class AfterScanFragment extends Fragment {
                 scanViewModel.completeScan(deviceId, null);
             }
             else {
+                // convert the bitmap to a byte array
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();
                 savedPhoto.compress(Bitmap.CompressFormat.PNG, 25, stream);
                 byte[] byteArray = stream.toByteArray();

--- a/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/ScanViewModel.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/ScanViewModel.java
@@ -46,13 +46,10 @@ public class ScanViewModel extends ViewModel {
      *
      * @param playerId The player that's scanning the qr code
      */
-    public void completeScan(String playerId, byte[] savedPhoto) {
+    public void completeScan(String qrCodeId, String playerId, byte[] savedPhoto) {
         ArrayList<Location> locations = new ArrayList<>();
         ArrayList<String> photos = new ArrayList<>();
 
-        FirebaseFirestore db = FirebaseFirestore.getInstance();
-        DocumentReference ref = db.collection("qrCodes").document();
-        String qrCodeId = ref.getId();
 
         // Don't add to location array if the location.latitude and location.longitude are 0
         if (location.getValue().getLatitude() != 0 || location.getValue().getLongitude() != 0) {


### PR DESCRIPTION
Closes #40, Closes #14

# Description (Updated)
<!-- 
A summary of the change. 
-->

- Stores the photos taken by the use to the Firebase Storage with path photos/qrCodeId/playerId
- A path is added to the qrCode for the image location (photos/qrCodeId/playerId.png); [remove the .png for using it it qrCode page]
- Deletes the photo from the storage when user deletes the qrCode
- Deletes location and path of the qrCode
- Fixed the issue where the image preview was of wrong aspect ratio and looked weird in AfterScanFragment
- Bug fixes 
- Refactoring

# Video
<!-- 
Any screenshot or recordings if applicable
-->
https://user-images.githubusercontent.com/112894386/227849583-3413872a-19f9-435e-bccd-6d02ac174959.mp4

# Screenshot of rounded corners

![Screenshot_20230326_233514](https://user-images.githubusercontent.com/112894386/227849844-97e85fc0-1f16-499c-ab2d-a7c3dc3efe59.png)



# Additional Context
<!-- 
Any additional context, reasons related to the pull request
-->

- Round the corners of image preview in AfterScanFragment to make it more asthetic


