### PR TITLE
Geolocation Bug Fix

### DIFF
--- a/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/QRCodeRepository.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/data/repository/QRCodeRepository.java
@@ -1,6 +1,5 @@
 package com.example.qrhunter.data.repository;
 
-import android.graphics.Bitmap;
 import android.util.Log;
 
 import androidx.lifecycle.LiveData;
@@ -245,8 +244,9 @@ public class QRCodeRepository extends DataRepository {
     public LiveData<List<QRCode>> getQRCodeList() {
         MutableLiveData<List<QRCode>> QRCodesLiveData = new MutableLiveData<>();
         CollectionReference QRCodesRef = db.collection("qrCodes");
-        QRCodesRef.get().addOnSuccessListener(queryDocumentSnapshots -> {
+        QRCodesRef.addSnapshotListener((queryDocumentSnapshots, error) -> {
             List<QRCode> QRCodes = new ArrayList<>();
+            assert queryDocumentSnapshots != null;
             for (QueryDocumentSnapshot document : queryDocumentSnapshots) {
                 QRCodes.add(QRCodeUtil.convertDocumentToQRCode(document));
             }

--- a/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/ScanViewModel.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/ScanViewModel.java
@@ -93,9 +93,8 @@ public class ScanViewModel extends ViewModel {
 
     public void setGeolocation(double latitude, double longitude) {
         Location currentLocation = this.location.getValue();
-        // Rounding to one decimal places
-        currentLocation.latitude = Math.round(latitude * 100.0) / 10.0;
-        currentLocation.longitude = Math.round(longitude * 100.0) / 10.0;
+        currentLocation.latitude = latitude;
+        currentLocation.longitude = longitude;
 
         location.setValue(currentLocation);
     }

--- a/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/ScanViewModel.java
+++ b/QRHunter/app/src/main/java/com/example/qrhunter/ui/scan/ScanViewModel.java
@@ -93,8 +93,8 @@ public class ScanViewModel extends ViewModel {
 
     public void setGeolocation(double latitude, double longitude) {
         Location currentLocation = this.location.getValue();
-        currentLocation.latitude = latitude;
-        currentLocation.longitude = longitude;
+        currentLocation.latitude = Math.round(latitude*10000d)/10000d;
+        currentLocation.longitude = Math.round(longitude*10000d)/10000d;
 
         location.setValue(currentLocation);
     }


### PR DESCRIPTION
# Description
<!-- 
A summary of the change. 
-->

- Change `setGeolocation()` class to set rounding to 4 decimal places
- Update `getQRCodeList()` to fix marker refresh

# Screenshot 
<!-- 
Any screenshot or recordings if applicable
-->
![image](https://user-images.githubusercontent.com/124106619/228322965-5d9b6107-2b01-4a16-adb7-39cddce63d26.png)
![image](https://user-images.githubusercontent.com/124106619/228322997-a1126c10-a93e-4e25-8029-1924993d0d59.png)

# Additional Context
<!-- 
Any additional context, reasons related to the pull request
-->
As seen in the screenshots above, rounding the locations to a whole number or one decimal place messes up the accuracy. Also, the multiplication set the location off by a factor of 10. This was changed when the location stuff was refactored so I'm guessing it was to aggregate the QRCodes that are in similar locations? 

